### PR TITLE
Add Respoke-SDK header to requests

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 06 16:47:37 CDT 2015
+#Fri Sep 25 20:01:03 CDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-all.zip

--- a/respokeSDK/src/main/java/com/digium/respokesdk/RespokeSignalingChannel.java
+++ b/respokeSDK/src/main/java/com/digium/respokesdk/RespokeSignalingChannel.java
@@ -30,6 +30,7 @@ import com.digium.respokesdk.RestAPI.APITransaction;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -251,7 +252,16 @@ public class RespokeSignalingChannel {
 
 
     public void authenticate() {
-        String connectURL = baseURL + ":" + RESPOKE_SOCKETIO_PORT + "?__sails_io_sdk_version=0.10.0&app-token=" + appToken;
+        String encodedSDKHeader = "Respoke-Android";
+        try {
+            encodedSDKHeader = URLEncoder.encode(APITransaction.getSDKHeader(), "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+
+        String connectURL = baseURL + ":" + RESPOKE_SOCKETIO_PORT +
+                "?__sails_io_sdk_version=0.10.0&app-token=" + appToken +
+                "&Respoke-SDK=" + encodedSDKHeader;
 
         SocketIOClient.connect(AsyncHttpClient.getDefaultInstance(), connectURL, new ConnectCallback() {
             @Override
@@ -563,7 +573,12 @@ public class RespokeSignalingChannel {
 
             try
             {
-                JSONObject message = new JSONObject("{'headers':{'App-Token':'" + appToken + "'},'url':'" + url + "'}");
+                JSONObject message = new JSONObject();
+                JSONObject headers = new JSONObject();
+                headers.put("App-Token", appToken);
+                headers.put("Respoke-SDK", APITransaction.getSDKHeader());
+                message.put("headers", headers);
+                message.put("url", url);
 
                 if (null != data) {
                     message.put("data", data);

--- a/respokeSDK/src/main/java/com/digium/respokesdk/RestAPI/APITransaction.java
+++ b/respokeSDK/src/main/java/com/digium/respokesdk/RestAPI/APITransaction.java
@@ -31,6 +31,8 @@ import android.content.Context;
 import android.os.AsyncTask;
 import android.util.Log;
 
+import com.digium.respokesdk.BuildConfig;
+
 
 public class APITransaction {
 
@@ -56,7 +58,18 @@ public class APITransaction {
     protected String params;
     protected int serverResponseCode;
     private AsyncTransaction asyncTrans;
-    
+
+    public static String getSDKHeader() {
+        String sdkTitle = "Respoke-Android";
+        String sdkVersion = BuildConfig.VERSION_NAME;
+        String androidVersion = android.os.Build.VERSION.RELEASE;
+
+        if (!sdkVersion.equals("")) {
+            sdkTitle = sdkTitle + "/" + sdkVersion;
+        }
+
+        return String.format("%s (Android %s)", sdkTitle, androidVersion);
+    }
     
     public APITransaction(Context context, String baseURL) {
     	this.context = context;
@@ -130,6 +143,7 @@ public class APITransaction {
                         //Headers
                         connection.setRequestProperty("Content-Type", contentType);
                         connection.setRequestProperty("Accept", "application/xml");
+                        connection.setRequestProperty("Respoke-SDK", getSDKHeader());
 
                         if (httpMethod.equals("POST")) {
                             //open stream and start writing


### PR DESCRIPTION
This patch adds the "Respoke-SDK" header to http and ws requests, as
well as the socket.io connect. When the sdk is being used outside of
a released environment (i.e. during development), the version number
of the sdk will not show, because there is no version number to be
displayed in that scenario. When the sdk is used from a distribution
such as Maven, the version number will be displayed along with the
name of the sdk, i.e. "Respoke-Android/1.2.0".

_Screenshot from logstash logs from running tests against production environment_
<img width="673" alt="screen shot 2015-09-25 at 10 36 35 pm" src="https://cloud.githubusercontent.com/assets/309219/10115666/49d9ee54-63d6-11e5-8463-2c3ce03e87b9.png">

Related to MER-4340.

PS I ran the tests and they pass.
