### PR TITLE
Start sending iceCandidates as soon as offer sent

### DIFF
--- a/respokeSDK/src/main/java/com/digium/respokesdk/RespokeSignalingChannel.java
+++ b/respokeSDK/src/main/java/com/digium/respokesdk/RespokeSignalingChannel.java
@@ -458,16 +458,16 @@ public class RespokeSignalingChannel {
 
                 JSONObject data = new JSONObject();
 
-                if ((null != lastKnownPushTokenID) && (!lastKnownPushTokenID.equals("notAvailable"))) {
-                    try {
-                        data.put("pushTokenId", lastKnownPushTokenID);
-                    } catch (JSONException e) {
-                        Log.d("", "Invalid JSON format for token");
-                    }
-                } else {
-                    data = null;
-                }
+                try {
+                    JSONObject parameters = new JSONObject("{ 'iceFinalCandidates': true }");
+                    data.put("capabilities", parameters);
 
+                    if ((null != lastKnownPushTokenID) && (!lastKnownPushTokenID.equals("notAvailable"))) {
+                        data.put("pushTokenId", lastKnownPushTokenID);
+                    }
+                } catch (Exception e) {
+                    Log.d(TAG, "Error creating JSON for endpoint connection creation");
+                }
 
                 // Once the socket is connected, perform a post to get the connection and endpoint IDs for this client
                 sendRESTMessage("post", "/v1/connections", data, new RESTListener() {
@@ -480,7 +480,6 @@ public class RespokeSignalingChannel {
                                     JSONObject responseJSON = (JSONObject) response;
                                     String endpointID = responseJSON.getString("endpointId");
                                     connectionID = responseJSON.getString("id");
-
 
                                     listener.onConnect(RespokeSignalingChannel.this, endpointID, connectionID);
                                 } catch (JSONException e) {


### PR DESCRIPTION
In a previous version of Respoke.js (which the android sdk was based on at the time of writing), we waited for the 'answer' signal to be received before sending any local iceCandidates to the remote peer.
Now that Respoke interops with Asterisk, it is important that these iceCandidates be sent as soon as possible after sending the offer, so that ice buffering will work properly.

This change is meant to address an issue a real-world use case was seeing, where an android device calling a chan_respoke endpoint was not able to get audio. From the looks of the debug traces we were sent, it was very possible that the required ice candidates to setup the call were not making it to our API backend in time to be included in the ice buffering payload that was being sent to chan_respoke after a buffering timeout.

We're still working on setting up a real-world test scenario to take these changes through the paces to see if they address the problem. I thought I would put this up for review, though, to get eyes on it.

FWIW, all the existing tests pass.
