### PR TITLE
Remove unnecessary inclusion of (massive) Google Play Services.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Respoke Android SDK Change Log
 ==============================
 
+v1.3.3
+------
+* Removed unnecessary inclusion of Google Play Services. The SDK doesn't actually use it. Client 
+apps should refer to the demo app for examples of how to use GCM (which relies on Google Play 
+Services).
+
 v1.3.2
 ------
 

--- a/respokeSDK/build.gradle
+++ b/respokeSDK/build.gradle
@@ -35,7 +35,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:22.2.0'
-    compile 'com.google.android.gms:play-services:7.5.0'
     compile 'io.pristine:libjingle:9340@aar'
     compile 'com.digium.respoke:AndroidAsync:2.1.6.1'
 }
@@ -69,7 +68,7 @@ signing {
 }
 
 group = "com.digium.respoke"
-version = "1.3.2"
+version = "1.3.3"
 
 uploadArchives {
   repositories {


### PR DESCRIPTION
Tests pass just fine without Google Play Services library. The clients will need the GCM library but the SDK shouldn't be pulling it in. Creates needless version conflicts for clients. 

<img width="1092" alt="screen shot 2015-12-14 at 11 22 39 am" src="https://cloud.githubusercontent.com/assets/2236390/11788994/7cc34830-a259-11e5-9f1c-b3ca156324d9.png">
