### PR TITLE
Check for null on getEndpoint when not forcing create

### DIFF
--- a/respokeSDK/src/main/java/com/digium/respokesdk/RespokeClient.java
+++ b/respokeSDK/src/main/java/com/digium/respokesdk/RespokeClient.java
@@ -1118,7 +1118,10 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
 
                                     for (String eachID : endpointIDsToRegister) {
                                         RespokeEndpoint endpoint = getEndpoint(eachID, true);
-                                        endpoint.resolvePresence();
+                                        
+                                        if (null != endpoint) {
+                                            endpoint.resolvePresence();
+                                        }
                                     }
                                 }
 


### PR DESCRIPTION
Chad and I saw this throw an exception when `endpoint` is null, which in turn closed the web socket.
