### PR TITLE
Message history updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,17 @@ dependencies {
     compile 'com.digium.respoke:respoke-sdk:1.+'
 }
 ```
-
 Building the SDK from source
 ============================
 
-We suggest using JDK 1.7. The code will build with JDK 1.8, but the androidJavadocs task will fail.
+You must use JDK 1.8.
 
 From the root directory:
 ```
     ./gradlew build
 ```
+
+NOTE: The javadoc generation task will complain with errors, but it will still generate the javadoc jar file.
 
 Contributing
 ============

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Apr 29 10:57:48 CDT 2016
+#Thu Dec 01 14:46:15 CST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/respokeSDK/build.gradle
+++ b/respokeSDK/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 
@@ -17,12 +17,16 @@ repositories {
 }
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion '22.0.1'
+    compileSdkVersion 23
+    buildToolsVersion '23.0.3'
+
+    configurations {
+        javadocDeps
+    }
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 22
+        targetSdkVersion 23
     }
 
     buildTypes {
@@ -35,7 +39,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.2.0'
+    compile 'com.android.support:appcompat-v7:23.2.0'
     compile 'io.pristine:libjingle:9340@aar'
     compile 'com.digium.respoke:AndroidAsync:2.1.7'
 }
@@ -44,12 +48,12 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 task androidJavadocs(type: Javadoc) {
+    options.addBooleanOption('Xdoclint:none', true)
     source = android.sourceSets.main.java.source
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-
-    //classpath.each {
-    //    println("classpath -> " + it);
-    //}
+    options.linkSource true
+    destinationDir = file("../javadoc/")
+    failOnError false
 }
 
 task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
@@ -74,7 +78,7 @@ signing {
 
 
 group = "com.digium.respoke"
-version = "1.4.1"
+version = "1.4.2"
 
 uploadArchives {
   repositories {

--- a/respokeSDK/respoke-sdk.iml
+++ b/respokeSDK/respoke-sdk.iml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id=":respoke-sdk" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/../../../../cirrus/android-app" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android-gradle" name="Android-Gradle">
+      <configuration>
+        <option name="GRADLE_PROJECT_PATH" value=":respoke-sdk" />
+      </configuration>
+    </facet>
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="SELECTED_BUILD_VARIANT" value="debug" />
+        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
+        <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
+        <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
+        <afterSyncTasks>
+          <task>generateDebugSources</task>
+        </afterSyncTasks>
+        <option name="ALLOW_USER_CONFIGURATION" value="false" />
+        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/src/main/res" />
+        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/src/main/assets" />
+        <option name="LIBRARY_PROJECT" value="true" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/aidl" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/jni" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/aidl" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/build/docs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotations" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/animated-vector-drawable/23.2.0/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.2.0/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.2.0/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-vector-drawable/23.2.0/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.digium.respoke/AndroidAsync/2.1.7/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/io.pristine/libjingle/9340/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/typedefs.txt" />
+      <excludeFolder url="file://$MODULE_DIR$/build/libs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
+    </content>
+    <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" exported="" name="support-v4-23.2.0" level="project" />
+    <orderEntry type="library" exported="" name="AndroidAsync-2.1.7" level="project" />
+    <orderEntry type="library" exported="" name="support-annotations-23.2.0" level="project" />
+    <orderEntry type="library" exported="" name="appcompat-v7-23.2.0" level="project" />
+    <orderEntry type="library" exported="" name="animated-vector-drawable-23.2.0" level="project" />
+    <orderEntry type="library" exported="" name="support-vector-drawable-23.2.0" level="project" />
+    <orderEntry type="library" exported="" name="libjingle-9340" level="project" />
+  </component>
+</module>

--- a/respokeSDK/src/main/java/com/digium/respokesdk/RespokeClient.java
+++ b/respokeSDK/src/main/java/com/digium/respokesdk/RespokeClient.java
@@ -33,6 +33,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static android.R.attr.data;
+import static android.R.attr.id;
+
 /**
  *  This is a top-level interface to the API. It handles authenticating the app to the
  *  API server, receiving server-side app-specific information, keeping track of connection status and presence,
@@ -69,13 +72,10 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
 
     public String baseURL = APITransaction.RESPOKE_BASE_URL;  ///< The base url of the Respoke service to use
 
-
     /**
      * A listener interface to notify the receiver of events occurring with the client
      */
     public interface Listener {
-
-
         /**
          *  Receive a notification Respoke has successfully connected to the cloud.
          *
@@ -92,7 +92,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
          */
         void onDisconnect(RespokeClient sender, boolean reconnecting);
 
-
         /**
          *  Handle an error that resulted from a method call.
          *
@@ -101,7 +100,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
          */
         void onError(RespokeClient sender, String errorMessage);
 
-
         /**
          *  Receive a notification that the client is receiving a call from a remote party.
          *
@@ -109,7 +107,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
          *  @param call   A reference to the incoming RespokeCall object
          */
         void onCall(RespokeClient sender, RespokeCall call);
-
 
         /**
          *  This event is fired when the logged-in endpoint is receiving a request to open a direct connection
@@ -120,7 +117,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
          *  @param endpoint          The remote endpoint initiating the direct connection
          */
         void onIncomingDirectConnection(RespokeDirectConnection directConnection, RespokeEndpoint endpoint);
-
 
         /**
          *  Receive a notification that a message addressed to this group has been received
@@ -133,7 +129,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
          */
         void onMessage(String message, RespokeEndpoint endpoint, RespokeGroup group, Date timestamp, Boolean didSend);
     }
-
 
     /**
      * A listener interface to receive a notification that the task to join the groups has completed
@@ -156,7 +151,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
 
     }
 
-
     /**
      * A listener interface to receive a notification that the connect action has failed
      */
@@ -170,7 +164,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         void onError(String errorMessage);
 
     }
-
 
     /**
      *  A listener interface to ask the receiver to resolve a list of presence values for an endpoint
@@ -187,7 +180,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         Object resolvePresence(ArrayList<Object> presenceArray);
 
     }
-
 
     /**
      * A listener interface to receive a notification when the request to retrieve the history
@@ -211,6 +203,43 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         void onError(String errorMessage);
     }
 
+    /**
+     * Encapsulates the info record for an Endpoint conversation.
+     */
+    static class EndpointConversationInfo {
+        public String groupId;
+        public Date timestamp;
+        public RespokeGroupMessage latestMessage;
+        public String sourceId;
+        public int unreadCount;
+
+        public EndpointConversationInfo() {
+        }
+
+        public EndpointConversationInfo(
+                String groupId,
+                Date timestamp,
+                RespokeGroupMessage message,
+                String sourceId,
+                int unreadCount) {
+            this.groupId = groupId;
+            this.timestamp = timestamp;
+            this.latestMessage = message;
+            this.sourceId = sourceId;
+            this.unreadCount = unreadCount;
+        }
+    }
+
+    /**
+     * A listener interface to receive a notification when the request to retrieve
+     * the list of conversations for an endpoint has completed.
+     */
+    public interface EndpointConversationsCompletionListener {
+
+        void onSuccess(List<EndpointConversationInfo> conversations);
+
+        void onError(String errorMessage);
+    }
 
     /**
      *  The constructor for this class
@@ -223,7 +252,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         presenceRegistered = new HashMap<String, Boolean>();
     }
 
-
     /**
      *  Set a receiver for the Listener interface
      *
@@ -233,7 +261,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         listenerReference = new WeakReference<Listener>(listener);
     }
 
-
     /**
      *  Set a receiver for the ResolvePresenceListener interface
      *
@@ -242,7 +269,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
     public void setResolvePresenceListener(ResolvePresenceListener listener) {
         resolveListenerReference = new WeakReference<ResolvePresenceListener>(listener);
     }
-
 
     /**
      *  Get the current receiver for the ResolvePresenceListener interface
@@ -256,7 +282,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
             return null;
         }
     }
-
 
     /**
      *  Connect to the Respoke infrastructure and authenticate in development mode using the specified endpoint ID and app ID.
@@ -306,7 +331,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         }
     }
 
-
     /**
      *  Connect to the Respoke infrastructure and authenticate with the specified brokered auth token ID. 
      *
@@ -346,7 +370,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         }
     }
 
-
     /**
      *  Disconnect from the Respoke infrastructure, leave all groups, invalidate the token, and disconnect the websocket.
      */
@@ -358,7 +381,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         }
     }
 
-
     /**
      *  Check whether this client is connected to the backend infrastructure.
      *
@@ -367,7 +389,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
     public boolean isConnected() {
         return ((signalingChannel != null) && (signalingChannel.connected));
     }
-
 
     /**
      *  Join a list of Groups and begin keeping track of them.
@@ -421,7 +442,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         }
     }
 
-
     /**
      *  Find a Connection by id and return it. In most cases, if we don't find it we will create it. This is useful
      *  in the case of dynamic endpoints where groups are not in use. Set skipCreate=true to return null
@@ -457,7 +477,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         return connection;
     }
 
-
     /**
      *  Initiate a call to a conference.
      *
@@ -479,7 +498,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
 
         return call;
     }
-
 
     /**
      *  Find an endpoint by id and return it. In most cases, if we don't find it we will create it. This is useful
@@ -515,7 +533,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         return endpoint;
     }
 
-
     /**
      *  Returns the group with the specified ID
      *
@@ -532,7 +549,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
 
         return group;
     }
-
 
     /**
      * Retrieve the history of messages that have been persisted for 1 or more groups. Only those
@@ -551,6 +567,10 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
     /**
      * Retrieve the history of messages that have been persisted for 1 or more groups. Only those
      * messages that have been marked to be persisted when sent will show up in the history.
+     *
+     * Note: This operation returns history for a set of specified groups. If you simply want the
+     * set of conversations that the connected endpoint has stored on the server (without needing to
+     * specify the groups), use the getConversations() method.
      *
      * @param groupIds The groups to pull history for
      * @param maxMessages The maximum number of messages per group to pull. Must be &gt;= 1
@@ -574,14 +594,20 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
             return;
         }
 
-        Uri.Builder builder = new Uri.Builder();
-        builder.appendQueryParameter("limit", maxMessages.toString());
-        for (String id: groupIds) {
-            builder.appendQueryParameter("groupIds", id);
+        JSONObject body = new JSONObject();
+        try {
+            body.put("limit", maxMessages.toString());
+            JSONArray groupIdParams = new JSONArray(groupIds);
+            body.put("groupIds", groupIdParams);
+        } catch(JSONException e) {
+            getGroupHistoriesError(completionListener, "Error forming JSON body to send.");
+            return;
         }
 
-        String urlEndpoint = "/v1/group-histories" + builder.build().toString();
-        signalingChannel.sendRESTMessage("get", urlEndpoint, null,
+        // This has been modifed to use the newer group-history-search route over the
+        // deprecated group-histories route.
+        String urlEndpoint = "/v1/group-history-search";
+        signalingChannel.sendRESTMessage("post", urlEndpoint, body,
                 new RespokeSignalingChannel.RESTListener() {
             @Override
             public void onSuccess(Object response) {
@@ -630,6 +656,133 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
                 getGroupHistoriesError(completionListener, errorMessage);
             }
         });
+    }
+
+    /**
+     * Retrieve a list of conversations (groupIds) that this endpoint has
+     * message history with. Only group messages that have been marked to be
+     * persisted will show up in history (and thus create a conversation).
+     *
+     * The success handler is passed a list of EndpointConversationInfo records.
+     *
+     * @param completionListener The callback called when this async operation has completed
+     */
+    public void getConversations(final EndpointConversationsCompletionListener completionListener) {
+        if (!isConnected()) {
+            getEndpointConversationsError(completionListener, "Can't complete request when not connected, " +
+                "Please reconnect!");
+            return;
+        }
+
+        String urlEndpoint = "/v1/endpoints/" + localEndpointID + "/conversations";
+        signalingChannel.sendRESTMessage("get", urlEndpoint, null,
+            new RespokeSignalingChannel.RESTListener() {
+                @Override
+                public void onSuccess(Object response) {
+                    if (!(response instanceof JSONObject)) {
+                        getEndpointConversationsError(completionListener, "Invalid response from server");
+                        return;
+                    }
+
+                    final JSONArray json = (JSONArray) response;
+                    final List<EndpointConversationInfo> results = new ArrayList<EndpointConversationInfo>();
+
+                    try {
+                        for (int i = 0; i < json.length(); i++) {
+                            final JSONObject jsonConversationInfo = json.getJSONObject(i);
+
+                            final EndpointConversationInfo info = new EndpointConversationInfo();
+
+                            final JSONObject jsonMessage = jsonConversationInfo.getJSONObject("message");
+                            info.latestMessage = buildGroupMessage(jsonMessage);
+                            info.groupId = jsonConversationInfo.getString("groupId");
+                            info.sourceId = jsonConversationInfo.getString("sourceId");
+                            info.unreadCount = jsonConversationInfo.getInt("unreadCount");
+                            info.timestamp = new Date(jsonConversationInfo.getLong("timestamp"));
+
+                            results.add(info);
+                        }
+                    } catch (JSONException e) {
+                        getEndpointConversationsError(completionListener, "Error parsing JSON response");
+                        return;
+                    }
+
+                    new Handler(Looper.getMainLooper()).post(new Runnable() {
+                        @Override
+                        public void run() {
+                            if (completionListener != null) {
+                                completionListener.onSuccess(results);
+                            }
+                        }
+                    });
+                }
+
+                @Override
+                public void onError(final String errorMessage) {
+                    getEndpointConversationsError(completionListener, errorMessage);
+                }
+            });
+    }
+
+    /**
+     * Mark messages in a conversation as having been read, up to the given timestamp
+     *
+     * @param updates An array of records, each of which indicates a groupId and timestamp of the
+     *                the most recent message the client has "read".
+     * @param completionListener The callback called when this async operation has completed.
+     */
+    public void setConversationsRead(final List<RespokeConversationReadStatus> updates, final Respoke.TaskCompletionListener completionListener) {
+        if (!isConnected()) {
+            Respoke.postTaskError(completionListener, "Can't complete request when not connected, " +
+                "Please reconnect!");
+            return;
+        }
+
+        if ((updates == null) || (updates.size() == 0)) {
+            Respoke.postTaskError(completionListener, "At least 1 conversation must be specified");
+            return;
+        }
+
+        JSONObject body = new JSONObject();
+        JSONArray groupsJsonArray = new JSONArray();
+
+        try {
+            // Add each status object to the array.
+            for (RespokeConversationReadStatus status : updates) {
+                JSONObject jsonStatus = new JSONObject();
+                jsonStatus.put("groupId", status.groupId);
+                jsonStatus.put("timestamp", status.timestamp.toString());
+
+                groupsJsonArray.put(jsonStatus);
+            }
+
+            // Set the array to the 'groups' property.
+            body.put("groups", groupsJsonArray);
+        } catch(JSONException e) {
+            Respoke.postTaskError(completionListener, "Error forming JSON body to send.");
+            return;
+        }
+
+        String urlEndpoint = "/v1/endpoints/" + localEndpointID + "/conversations";
+        signalingChannel.sendRESTMessage("put", urlEndpoint, body,
+            new RespokeSignalingChannel.RESTListener() {
+                @Override
+                public void onSuccess(Object response) {
+                    new Handler(Looper.getMainLooper()).post(new Runnable() {
+                        @Override
+                        public void run() {
+                            if (completionListener != null) {
+                                completionListener.onSuccess();
+                            }
+                        }
+                    });
+                }
+
+                @Override
+                public void onError(final String errorMessage) {
+                    Respoke.postTaskError(completionListener, errorMessage);
+                }
+            });
     }
 
     /**
@@ -747,7 +900,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         return localEndpointID;
     }
 
-
     /**
      *  Set the presence on the client session
      *
@@ -792,7 +944,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         }
     }
 
-
     /**
      *  Get the current presence of this client
      *
@@ -801,7 +952,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
     public Object getPresence() {
         return presence;
     }
-
 
     /**
      *  Register the client to receive push notifications when the socket is not active
@@ -882,9 +1032,7 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         }
     }
 
-
     //** Private methods
-
 
     private void createOrUpdatePushServiceToken(final String token, String httpURI, String httpMethod, JSONObject data, final SharedPreferences prefs) {
         signalingChannel.sendRESTMessage(httpMethod, httpURI, data, new RespokeSignalingChannel.RESTListener() {
@@ -914,7 +1062,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         });
     }
 
-
     /**
      *  A convenience method for posting errors to a ConnectCompletionListener
      *
@@ -932,7 +1079,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         });
     }
 
-
     /**
      *  A convenience method for posting errors to a JoinGroupCompletionListener
      *
@@ -944,6 +1090,18 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
             @Override
             public void run() {
                 if (null != completionListener) {
+                    completionListener.onError(errorMessage);
+                }
+            }
+        });
+    }
+
+    private void getEndpointConversationsError(final EndpointConversationsCompletionListener completionListener,
+                                        final String errorMessage) {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                if (completionListener != null) {
                     completionListener.onError(errorMessage);
                 }
             }
@@ -974,7 +1132,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         });
     }
 
-
     /**
      *  Attempt to reconnect the client after a small delay
      */
@@ -993,7 +1150,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
             );
         }
     }
-
 
     /**
      *  Attempt to reconnect the client if it is not already trying in another thread
@@ -1026,7 +1182,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
             }
         }
     }
-
 
     /**
      *  Register for presence updates for the specified endpoint ID. Registration will not occur immediately, 
@@ -1137,10 +1292,7 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         }
     }
 
-
     // RespokeSignalingChannelListener methods
-
-
     public void onConnect(RespokeSignalingChannel sender, String endpointID, String connectionID) {
         connectionInProgress = false;
         reconnectCount = 0;
@@ -1173,7 +1325,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         });
     }
 
-
     public void onDisconnect(RespokeSignalingChannel sender) {
         // Can only reconnect in development mode, not brokered mode
         final boolean willReconnect = reconnect && (applicationID != null);
@@ -1202,7 +1353,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         }
     }
 
-
     public void onIncomingCall(JSONObject sdp, String sessionID, String connectionID, String endpointID, String fromType, Date timestamp, RespokeSignalingChannel sender) {
         RespokeEndpoint endpoint = null;
 
@@ -1229,7 +1379,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         });
     }
 
-
     public void onIncomingDirectConnection(JSONObject sdp, String sessionID, String connectionID, String endpointID, Date timestamp, RespokeSignalingChannel sender) {
         RespokeEndpoint endpoint = getEndpoint(endpointID, false);
 
@@ -1239,7 +1388,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
             Log.d(TAG, "Error: Could not create Endpoint for incoming direct connection");
         }
     }
-
 
     public void onError(final String errorMessage, RespokeSignalingChannel sender) {
         new Handler(Looper.getMainLooper()).post(new Runnable() {
@@ -1261,7 +1409,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         }
     }
 
-
     public void onJoinGroup(String groupID, String endpointID, String connectionID, RespokeSignalingChannel sender) {
         // only pass on notifications about people other than ourselves
         if ((null != endpointID) && (!endpointID.equals(localEndpointID))) {
@@ -1278,7 +1425,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         }
     }
 
-
     public void onLeaveGroup(String groupID, String endpointID, String connectionID, RespokeSignalingChannel sender) {
         // only pass on notifications about people other than ourselves
         if ((null != endpointID) && (!endpointID.equals(localEndpointID))) {
@@ -1294,7 +1440,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
             }
         }
     }
-
 
     private void didReceiveMessage(final RespokeEndpoint endpoint, final String message, final Date timestamp) {
         new Handler(Looper.getMainLooper()).post(new Runnable() {
@@ -1348,7 +1493,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         }
     }
 
-
     public void onGroupMessage(final String message, String groupID, String endpointID, RespokeSignalingChannel sender, final Date timestamp) {
         final RespokeGroup group = groups.get(groupID);
 
@@ -1373,7 +1517,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         }
     }
 
-
     public void onPresence(Object presence, String connectionID, String endpointID, RespokeSignalingChannel sender) {
         RespokeConnection connection = getConnection(connectionID, endpointID, false);
 
@@ -1385,16 +1528,13 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         }
     }
 
-
     public void callCreated(RespokeCall call) {
         calls.add(call);
     }
 
-
     public void callTerminated(RespokeCall call) {
         calls.remove(call);
     }
-
 
     public RespokeCall callWithID(String sessionID) {
         RespokeCall call = null;
@@ -1409,7 +1549,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
         return call;
     }
 
-
     public void directConnectionAvailable(final RespokeDirectConnection directConnection, final RespokeEndpoint endpoint) {
         new Handler(Looper.getMainLooper()).post(new Runnable() {
             @Override
@@ -1423,7 +1562,6 @@ public class RespokeClient implements RespokeSignalingChannel.Listener {
             }
         });
     }
-
 
     /**
      * Build a group message from a JSON object. The format of the JSON object would be the

--- a/respokeSDK/src/main/java/com/digium/respokesdk/RespokeConversationReadStatus.java
+++ b/respokeSDK/src/main/java/com/digium/respokesdk/RespokeConversationReadStatus.java
@@ -1,0 +1,19 @@
+package com.digium.respokesdk;
+
+import java.util.Date;
+
+import static android.R.id.message;
+
+/**
+ *
+ */
+
+public class RespokeConversationReadStatus {
+    public String groupId;
+    public Date timestamp;
+
+    public RespokeConversationReadStatus(String groupId, Date timestamp) {
+        this.groupId = groupId;
+        this.timestamp = timestamp;
+    }
+}

--- a/respokeSDKTest/build.gradle
+++ b/respokeSDKTest/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion '22.0.1'
+    compileSdkVersion 23
+    buildToolsVersion '23.0.3'
 
     defaultConfig {
         applicationId "com.digium.respokesdktest"
         minSdkVersion 15
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
@@ -26,6 +26,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.1.1'
+    compile 'com.android.support:appcompat-v7:23.2.0'
     compile project(':respokeSDK')
 }


### PR DESCRIPTION
- Moved RespokeClient.getGroupHistories() to a new route from a deprecated one.
- Added RespokeClient.getConversations() and .setConversationsRead() for server-side message history support.

Note: Most of the changes are to RespokeClient. There are some other changes related to JDK and javadoc generation because of the requirement to move to JDK 1.8 for current Android SDKs. 